### PR TITLE
Move from Alpine to SLE BCI micro and run as non-root user

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,13 +1,14 @@
-FROM golang:1.17.6 AS helm
+FROM registry.suse.com/bci/golang:1.17 AS helm
+RUN zypper -n install git
 RUN git -C / clone --branch release-v3.8.0 --depth=1 https://github.com/rancher/helm
 RUN make -C /helm
 
-FROM golang:1.17.8-alpine3.15
+FROM registry.suse.com/bci/golang:1.17
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
-RUN apk -U add bash git gcc musl-dev docker vim less file curl wget ca-certificates
+RUN zypper -n install git docker vim less file curl wget
 RUN go get golang.org/x/tools/cmd/goimports
 RUN if [ "${ARCH}" == "amd64" ]; then \
         curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.40.1; \
@@ -19,6 +20,7 @@ ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS
 ENV DAPPER_SOURCE /go/src/github.com/aiyengar2/helm-project-operator/
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true
+ENV GOPATH /go
 ENV HOME ${DAPPER_SOURCE}
 WORKDIR ${DAPPER_SOURCE}
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,3 +1,8 @@
-FROM alpine
+FROM registry.suse.com/bci/bci-micro:15.3
+RUN echo 'prometheus:x:1000:1000::/home/prometheus:/bin/bash' >> /etc/passwd && \
+    echo 'prometheus:x:1000:' >> /etc/group && \
+    mkdir /home/prometheus && \
+    chown -R prometheus:prometheus /home/prometheus
 COPY bin/prometheus-federator /usr/bin/
+USER prometheus
 CMD ["prometheus-federator"]


### PR DESCRIPTION
This is a proposal to move from Alpine to SLE [BCI micro](https://registry.suse.com/static/bci/bci-micro/index.html) and run as non-root user.

BCI micro it's only a few MBs bigger than Alpine. Size comparison:

```
rancher/prometheus-federator   0514031-amd64   2898f3ead76d  37 seconds ago   43.2MB     <-- Alpine
rancher/prometheus-federator   38f0174-amd64   d79d8abea0ac  9 seconds ago    61.4MB     <-- BCI micro
```

The user is created manually, because BCI micro doesn't have `useradd` command.

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>